### PR TITLE
Standardize Docker compose: use COPY instead of volume mounts

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,3 +6,4 @@ ENV BASH_ENV="/etc/bash_env"
 RUN sudo apt-get update && sudo apt-get upgrade -y
 RUN python3 -m pip install --upgrade dqrobotics --break-system-packages
 RUN mkdir -p /root/sas_ur_control_template_devel/src/
+COPY . /root/sas_ur_control_template_devel/src/sas_ur_control_template

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,8 +1,8 @@
 services:
   sas_ur_control_template:
-    build: .
-    volumes:
-      - ../../sas_ur_control_template:/root/sas_ur_control_template_devel/src/sas_ur_control_template
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
     command: /bin/bash -c "
       cd /root/sas_ur_control_template_devel/src/
       && ls .


### PR DESCRIPTION
Standardize Docker configuration to match `sas_core` pattern.

**Changes:**
- Add `COPY . /root/sas_ur_control_template_devel/src/sas_ur_control_template` to Dockerfile
- Change `compose.yml` build context to parent directory with explicit `dockerfile: docker/Dockerfile`
- Remove source volume mount from `compose.yml`

---

This PR was created by an AI agent (OpenHands) on behalf of mmmarinho.